### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flutter_build.yml
+++ b/.github/workflows/flutter_build.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/JDODER260/Pick-Up-Form-v4/security/code-scanning/1](https://github.com/JDODER260/Pick-Up-Form-v4/security/code-scanning/1)

In general, the fix is to declare an explicit `permissions:` block that grants the least privilege required by this workflow. Because this job only needs to read the repository contents (for `actions/checkout`) and does not interact with pull requests, issues, or releases, it can safely operate with `contents: read` and otherwise default to `none`.

The best minimal change is to add a `permissions:` block at the top (workflow) level so it applies to all jobs, without altering any existing steps. We’ll insert it after the `on:` trigger block and before `jobs:`. Specifically, in `.github/workflows/flutter_build.yml`, between line 8 (`pull_request:`) and line 9 (`jobs:`), add:

```yaml
permissions:
  contents: read
```

No additional imports or methods are needed; this is pure workflow configuration. This keeps functionality identical while ensuring `GITHUB_TOKEN` is restricted to read-only repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
